### PR TITLE
Pull the RGB2LAB <-> LAB2RGB conversion into a proxy class

### DIFF
--- a/python/src/goldfinch/__init__.py
+++ b/python/src/goldfinch/__init__.py
@@ -1,1 +1,1 @@
-from .sharpener import Sharpener
+from .sharpener import Sharpener, LabSharpener

--- a/python/src/goldfinch/sharpener.py
+++ b/python/src/goldfinch/sharpener.py
@@ -46,11 +46,9 @@ class Sharpener:
             raise BadInputImage(
                 "Input image must be 3 dimensional: [X, Y, color_encoding]"
             )
-        src = color.rgb2lab(src)
         output = 0 * src
         for i in range(src.shape[-1]):
             output[:, :, i] = self._correlate(i, src, self.Kernel)
-        output = img_as_ubyte(color.lab2rgb(output))
         return output
 
     def _correlate(self, i: int, src: array, kernel: array):
@@ -65,3 +63,11 @@ class Sharpener:
 
     def _correlate_brute(self):
         pass
+
+
+class LabSharpener(Sharpener):
+    def sharpen_image(self, src: np.array):
+        src = color.rgb2lab(src)
+        output = super().sharpen_image(src)
+        output = img_as_ubyte(color.lab2rgb(output))
+        return output

--- a/python/tests/test_sharpener.py
+++ b/python/tests/test_sharpener.py
@@ -7,10 +7,11 @@ import pytest
 import imageio.v3 as iio
 import numpy as np
 
-from goldfinch import Sharpener
+from goldfinch import Sharpener, LabSharpener
 
 TEST_INPUT = "INPUT"
 TEST_OUTPUT = "OUTPUT"
+SHARPENER = "sharpener"
 
 
 @pytest.fixture
@@ -67,10 +68,12 @@ def test_data(
         "MOUSE": {
             TEST_INPUT: input_mouse,
             TEST_OUTPUT: sharpened_mouse,
+            SHARPENER: LabSharpener,
         },
         "BASIC": {
             TEST_INPUT: input_basic,
             TEST_OUTPUT: sharpened_basic,
+            SHARPENER: Sharpener,
         },
     }
     yield outputs[request.param]
@@ -81,7 +84,7 @@ def test_sharpener(test_data):
     """
     First test.
     """
-    my_sharpener = Sharpener()
+    my_sharpener = test_data[SHARPENER]()
     test_sharpened_image = my_sharpener.sharpen_image(test_data[TEST_INPUT])
     # Uncomment for debugging.
     # iio.imwrite("test_output.png", test_sharpened_image)


### PR DESCRIPTION
Pull the RGB2LAB conversion stuff into a specific class to follow the SRP.

Changelist:
- Creates `LabSharpener(Sharpener)`
- Updates test to test both classes.